### PR TITLE
Consuming Group in Json format

### DIFF
--- a/src/main/java/com/softserve/teamproject/controller/GroupController.java
+++ b/src/main/java/com/softserve/teamproject/controller/GroupController.java
@@ -55,7 +55,7 @@ public class GroupController {
   }
 
   /**
-   * Method creates a group received in body in json format. Note: teh date format accepted:
+   * Method creates a group received in body in json format. Note: the date format accepted:
    * "yyyy-MM-dd"
    *
    * @param group in json format, which is automatically transformed into the object of the Group

--- a/src/main/java/com/softserve/teamproject/controller/GroupController.java
+++ b/src/main/java/com/softserve/teamproject/controller/GroupController.java
@@ -67,8 +67,14 @@ public class GroupController {
     groupService.addGroup(group, principal.getName());
   }
 
+  /**
+   * Methods deletes the group by id.
+   * @param id is received as a path variable
+   * @param principal helps to identify the authenticated user
+   */
   @RequestMapping(value = "/groups/{id}", method = RequestMethod.DELETE)
   public void deleteGroup(@PathVariable Integer id, Principal principal) {
     groupService.deleteGroup(id, principal.getName());
   }
+
 }

--- a/src/main/java/com/softserve/teamproject/controller/GroupController.java
+++ b/src/main/java/com/softserve/teamproject/controller/GroupController.java
@@ -8,6 +8,7 @@ import java.util.List;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -52,9 +53,17 @@ public class GroupController {
   public List<Group> getAllGroups() {
     return groupService.getAllGroups();
   }
-  
+
+  /**
+   * Method creates a group received in body in json format. Note: teh date format accepted:
+   * "yyyy-MM-dd"
+   *
+   * @param group in json format, which is automatically transformed into the object of the Group
+   * type
+   * @param principal to get the name of the authenticated user
+   */
   @RequestMapping(value = "/groups", method = RequestMethod.POST)
-  public void createGroup(@Valid Group group, Principal principal) {
+  public void createGroup(@RequestBody @Valid Group group, Principal principal) {
     groupService.addGroup(group, principal.getName());
   }
 

--- a/src/main/java/com/softserve/teamproject/entity/Group.java
+++ b/src/main/java/com/softserve/teamproject/entity/Group.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.softserve.teamproject.entity.deserializer.LocalDateDeserializer;
 import com.softserve.teamproject.entity.deserializer.LocalDateSerializer;
+import com.softserve.teamproject.entity.deserializer.LocationDeserializer;
 import com.softserve.teamproject.entity.deserializer.StatusDeserializer;
 import com.softserve.teamproject.entity.deserializer.UserDeserializer;
 import com.softserve.teamproject.entity.enums.BudgetOwner;
@@ -54,6 +55,7 @@ public class Group {
   @ManyToOne
   @JoinColumn(name = "location_id", referencedColumnName = "id", nullable = false)
   @NotNull
+  @JsonDeserialize(using = LocationDeserializer.class)
   private Location location;
 
   @Column(name = "start_date", columnDefinition = "DATE")

--- a/src/main/java/com/softserve/teamproject/entity/Group.java
+++ b/src/main/java/com/softserve/teamproject/entity/Group.java
@@ -1,18 +1,29 @@
 package com.softserve.teamproject.entity;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.softserve.teamproject.entity.deserializer.LocalDateDeserializer;
+import com.softserve.teamproject.entity.deserializer.LocalDateSerializer;
+import com.softserve.teamproject.entity.deserializer.StatusDeserializer;
+import com.softserve.teamproject.entity.deserializer.UserDeserializer;
 import com.softserve.teamproject.entity.enums.BudgetOwner;
 import com.softserve.teamproject.validation.StringConstraintInSet;
 import com.softserve.teamproject.validation.UniqueGroup;
-import java.util.Set;
-import javax.persistence.*;
 import java.time.LocalDate;
 import java.util.Objects;
+import java.util.Set;
+import javax.persistence.CollectionTable;
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
@@ -37,6 +48,7 @@ public class Group {
   @ManyToMany
   @JoinTable(name = "group_teacher", joinColumns = { @JoinColumn(name = "group_id")},
   inverseJoinColumns = { @JoinColumn(name = "teacher_id")})
+  @JsonDeserialize(using= UserDeserializer.class)
   private Set<User> teachers;
 
   @ManyToOne
@@ -46,14 +58,19 @@ public class Group {
 
   @Column(name = "start_date", columnDefinition = "DATE")
   @DateTimeFormat(pattern = "dd/MM/yyyy")
+  @JsonDeserialize(using = LocalDateDeserializer.class)
+  @JsonSerialize(using = LocalDateSerializer.class)
   private LocalDate startDate;
 
   @Column(name = "finish_date", columnDefinition = "DATE")
   @DateTimeFormat(pattern = "dd/MM/yyyy")
+  @JsonDeserialize(using = LocalDateDeserializer.class)
+  @JsonSerialize(using = LocalDateSerializer.class)
   private LocalDate finishDate;
 
   @ManyToOne
   @JoinColumn(name = "status_id", referencedColumnName = "id", nullable = false)
+  @JsonDeserialize(using= StatusDeserializer.class)
   private Status status;
 
   @ManyToOne

--- a/src/main/java/com/softserve/teamproject/entity/deserializer/LocalDateDeserializer.java
+++ b/src/main/java/com/softserve/teamproject/entity/deserializer/LocalDateDeserializer.java
@@ -1,0 +1,24 @@
+package com.softserve.teamproject.entity.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.node.TextNode;
+import java.io.IOException;
+import java.time.LocalDate;
+
+public class LocalDateDeserializer extends JsonDeserializer<LocalDate> {
+
+  @Override
+  public LocalDate deserialize(JsonParser jp, DeserializationContext deserializationContext)
+      throws IOException, JsonProcessingException {
+
+    ObjectCodec oc = jp.getCodec();
+    TextNode node = (TextNode) oc.readTree(jp);
+    String dateString = node.textValue();
+    LocalDate date = LocalDate.parse(dateString);
+    return date;
+  }
+}

--- a/src/main/java/com/softserve/teamproject/entity/deserializer/LocalDateDeserializer.java
+++ b/src/main/java/com/softserve/teamproject/entity/deserializer/LocalDateDeserializer.java
@@ -9,6 +9,10 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import java.io.IOException;
 import java.time.LocalDate;
 
+/**
+ * Class provides the implementation of the deserialization method to describe how extactly the json
+ * date is going to be deserialized and parsed.
+ */
 public class LocalDateDeserializer extends JsonDeserializer<LocalDate> {
 
   @Override

--- a/src/main/java/com/softserve/teamproject/entity/deserializer/LocalDateSerializer.java
+++ b/src/main/java/com/softserve/teamproject/entity/deserializer/LocalDateSerializer.java
@@ -1,0 +1,23 @@
+package com.softserve.teamproject.entity.deserializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDateSerializer extends JsonSerializer<LocalDate> {
+
+  private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+
+  @Override
+  public void serialize(LocalDate date, JsonGenerator generator,
+      SerializerProvider provider) throws IOException,
+      JsonProcessingException {
+
+    String dateString = date.format(formatter);
+    generator.writeString(dateString);
+  }
+}

--- a/src/main/java/com/softserve/teamproject/entity/deserializer/LocalDateSerializer.java
+++ b/src/main/java/com/softserve/teamproject/entity/deserializer/LocalDateSerializer.java
@@ -10,7 +10,7 @@ import java.time.format.DateTimeFormatter;
 
 public class LocalDateSerializer extends JsonSerializer<LocalDate> {
 
-  private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+  private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
   @Override
   public void serialize(LocalDate date, JsonGenerator generator,

--- a/src/main/java/com/softserve/teamproject/entity/deserializer/LocationDeserializer.java
+++ b/src/main/java/com/softserve/teamproject/entity/deserializer/LocationDeserializer.java
@@ -1,0 +1,30 @@
+package com.softserve.teamproject.entity.deserializer;
+
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.softserve.teamproject.entity.Location;
+import com.softserve.teamproject.repository.LocationRepository;
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LocationDeserializer extends JsonDeserializer<Location> {
+
+  @Autowired
+  LocationRepository locationRepository;
+
+  @Override
+  public Location deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+      throws IOException, JsonProcessingException {
+    ObjectCodec oc = jsonParser.getCodec();
+    JsonNode node = oc.readTree(jsonParser);
+    Location location=locationRepository.findOne(node.get("id").asInt());
+    return location;
+  }
+}

--- a/src/main/java/com/softserve/teamproject/entity/deserializer/StatusDeserializer.java
+++ b/src/main/java/com/softserve/teamproject/entity/deserializer/StatusDeserializer.java
@@ -1,0 +1,29 @@
+package com.softserve.teamproject.entity.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.softserve.teamproject.entity.Status;
+import com.softserve.teamproject.repository.StatusRepository;
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StatusDeserializer extends JsonDeserializer<Status> {
+
+  @Autowired
+  StatusRepository statusRepository;
+
+  @Override
+  public Status deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+      throws IOException, JsonProcessingException {
+    ObjectCodec oc = jsonParser.getCodec();
+    JsonNode node = oc.readTree(jsonParser);
+    Status status=statusRepository.findOne(node.get("id").asInt());
+    return status;
+  }
+}

--- a/src/main/java/com/softserve/teamproject/entity/deserializer/UserDeserializer.java
+++ b/src/main/java/com/softserve/teamproject/entity/deserializer/UserDeserializer.java
@@ -1,0 +1,37 @@
+package com.softserve.teamproject.entity.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.softserve.teamproject.entity.User;
+import com.softserve.teamproject.repository.UserRepository;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserDeserializer extends JsonDeserializer<Set<User>> {
+
+  @Autowired
+  UserRepository userRepository;
+
+  @Override
+  public Set<User> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+      throws IOException, JsonProcessingException {
+    Set<User> users=new HashSet<>();
+    ObjectCodec oc = jsonParser.getCodec();
+    JsonNode node = oc.readTree(jsonParser);
+    if (node.isArray()) {
+      for (final JsonNode objNode : node) {
+        User user=userRepository.findOne(objNode.get("id").asInt());
+        users.add(user);
+      }
+    }
+    return users;
+  }
+}


### PR DESCRIPTION
Now the controllers can consume groups received from the front end in json format. For that purpose deserialization classes were added as well as the corresponding annotations in the Group entity.