### PR TITLE
Fixed NullPointerException in the hashcode() method (Student)

### DIFF
--- a/src/main/java/com/softserve/teamproject/entity/Student.java
+++ b/src/main/java/com/softserve/teamproject/entity/Student.java
@@ -111,7 +111,7 @@ public class Student {
 
   @Override
   public int hashCode() {
-    return Objects.hash(firstName, lastName, group.getId());
+    return Objects.hash(firstName, lastName);
   }
 
   @Override


### PR DESCRIPTION
When we try to add new student, we get NullPointerException in the field Group in Student entity, because Group field hasn't been set yet.